### PR TITLE
Fermant Numbers Code in Python

### DIFF
--- a/fermant_numbers.py
+++ b/fermant_numbers.py
@@ -1,0 +1,14 @@
+"""
+    Returns the nth Fermat number: F_n = 2^(2^n) + 1 for any positive 'n'.
+"""
+
+
+def fermat_number(n):
+
+    if n < 0:
+        raise ValueError("n must be a non-negative integer")
+    return 2 ** (2 ** n) + 1
+
+# Example usage:
+for i in range(6):
+    print(f"F_{i} = {fermat_number(i)}")


### PR DESCRIPTION
#  Fermat Number Generator

A simple Python program that calculates the **n-th Fermat number**, defined as

[
F_n = 2^{2^n} + 1
]

This project is part of my **Hacktoberfest 2025** open-source contribution.



##  About Fermat Numbers

Fermat numbers are named after **Pierre de Fermat**, who conjectured that all numbers of the form
[
F_n = 2^{2^n} + 1
]
are prime.
This is true only for `n = 0, 1, 2, 3, 4`. All known higher Fermat numbers are **composite**(yet).

---
