### PR TITLE
Add Postfix to Infix Converter (C++) with README

### DIFF
--- a/postfix-to-infix-c++/README.md
+++ b/postfix-to-infix-c++/README.md
@@ -1,0 +1,26 @@
+# Postfix to Infix Converter (C++)
+
+## Description
+This program converts a postfix (Reverse Polish Notation) expression
+to its equivalent infix expression using a stack.
+
+It demonstrates stack-based expression parsing, operator/operand handling,
+and outputs fully parenthesized infix expressions.
+
+## How to Compile
+```bash
+g++ postfix_to_infix.cpp -o postfix_to_infix
+```
+## How to Run
+```bash
+./postfix_to_infix
+```
+## Example
+
+Input: `AB+C*`
+Output: `((A + B) * C)`
+
+## Features
+- Stack-based implementation
+- Fully parenthesized infix expression
+- Handles single-letter/numeric operands

--- a/postfix-to-infix-c++/postfix_to_infix.cpp
+++ b/postfix-to-infix-c++/postfix_to_infix.cpp
@@ -1,0 +1,53 @@
+#include<bits/stdc++.h>
+using namespace std;
+
+// Function to check if a character is an operator
+bool isOperator(char c) {
+    return (c=='+'||c=='-'||c=='*'||c=='/'||c=='^');
+}
+
+// Function to convert Postfix to Infix
+string postfixToInfix(const string& postfix) {
+    stack<string> st;
+
+    for(char c:postfix) {
+        // If operand, push it to stack
+        if(isalnum(c)) {
+            st.push(string(1,c));
+        }
+        // If operator, pop two operands and combine
+        else if(isOperator(c)) {
+            if(st.size()<2) {
+                cerr << "Invalid postfix expression!" << endl;
+                return "";
+            }
+            string op2=st.top();st.pop();
+            string op1=st.top();st.pop();
+            
+            // Form the new infix expression
+            string infix="(" +op1+" "+c+" "+op2+ ")";
+            st.push(infix);
+        }
+    }
+
+    // Final expression should be the only element in the stack
+    if(st.size()!=1){
+        cerr<<"Invalid postfix expression!"<<endl;
+        return "";
+    }
+
+    return st.top();
+}
+
+int main() {
+    string postfix;
+    cout<<"Enter a postfix expression: ";
+    cin>>postfix;
+
+    string infix=postfixToInfix(postfix);
+    if(!infix.empty()) {
+        cout<<"Infix Expression: "<<infix<<endl;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This PR adds a C++ program that converts postfix expressions into fully parenthesized infix expressions using a stack.

Features:
- Stack-based implementation
- Fully parenthesized infix output
- Handles single-letter/numeric operands

Includes a README with:
- Project description
- Compilation and execution instructions
- Example input/output
- Features list

Related to Issue #3132
Closes #3132